### PR TITLE
Leak less information if strings are not equal in length

### DIFF
--- a/pypy/streql.py
+++ b/pypy/streql.py
@@ -7,10 +7,12 @@ def equals(x, y):
   if isinstance(y, unicode):
     y = y.encode('utf8')
 
-  if len(x) != len(y):
-    return False
+  if len(x) > len(y):
+    minlen = len(y)
+  else:
+    minlen = len(x)
 
   result = i = 0
-  for i in xrange(len(x)):
+  for i in xrange(minlen):
     result |= ord(x[i]) ^ ord(y[i])
-  return result == 0
+  return result == 0 and len(x) == len(y)

--- a/streql.c
+++ b/streql.c
@@ -2,11 +2,12 @@
 
 // The core function: test two regions of memory for bytewise equality.
 static int equals_internal(const char *x, unsigned int xlen, const char *y, unsigned int ylen) {
-  if (xlen != ylen) return 0;
-
+  int minlen = ( xlen > ylen ) ? ylen : xlen;
   int i, result = 0;
-  for (i = 0; i < xlen; i++) result |= x[i] ^ y[i];
-  return result == 0;
+
+  for (i = 0; i < minlen; i++) result |= x[i] ^ y[i];
+
+  return ( xlen == ylen ) && ( result == 0 );
 }
 
 


### PR DESCRIPTION
I'm currently packaging streql for Debian (https://lists.debian.org/debian-security/2014/10/msg00063.html) and this issue came up:

If two strings are that are not equal in length are compared, no further equality checking is done, meaning that comparing two strings of different length takes a lot less time than comparing two strings of the same length.

This pull request tries to fix that, by performing an equality check for as many characters as possible in strings of unequal length, thus increasing the time taken to perform the equality check. Some length information is still leaked, but not as obviously.
